### PR TITLE
update GitHub project name in setup url arg

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ setup(
     description=('Construct arbitrarily complex Django "Q" filters from flat '
                  'data, such as query parameters.'),
     long_description=open('README.rst').read(),
-    url='http://github.com/bennullgraham/django-filternaut/',
+    url='https://github.com/bennullgraham/filternaut',
     license='BSD',
     packages=['filternaut'],
     install_requires=['six>=1.9.0'],


### PR DESCRIPTION
django-filternaut -> filternaut (also http -> https and no trailing-slash as per GitHub canonical form)

It's a tiny thing but it broke the link form PyPI. Feel free to disregard this PR and merge the change in with whatever your next edit of setup.py happens to be. 😄 

Thanks for sharing your code!